### PR TITLE
Fix saved tasks actually being correctly stored as scheduler expects

### DIFF
--- a/Classes/Service/DatabaseTasksService.php
+++ b/Classes/Service/DatabaseTasksService.php
@@ -63,6 +63,10 @@ class DatabaseTasksService
             );
         }
 
+        // Make sure to save the taskUid in the task itself
+        $task->setTaskUid($uid);
+        $task->save();
+
         return $uid;
     }
 

--- a/Classes/Service/SyncTasksService.php
+++ b/Classes/Service/SyncTasksService.php
@@ -87,7 +87,7 @@ class SyncTasksService
             }
             unset($remaining[$identifier]);
 
-            $sha1 = sha1(serialize($taskDetails));
+            $sha1 = sha1(serialize($taskDetails) . 'v2');
             if (isset($dbTasks[$identifier])) {
                 // Yaml task is already in the database
                 if ($dbTasks[$identifier]['tx_cronjobs_sha1'] !== $sha1) {

--- a/Classes/Service/SyncTasksService.php
+++ b/Classes/Service/SyncTasksService.php
@@ -167,7 +167,7 @@ class SyncTasksService
 
         }
 
-        $task->registerRecurringExecution(0, $taskDetails['interval'] ?? null, 0, false, $taskDetails['cronCmd'] ?? null);
+        $task->registerRecurringExecution($GLOBALS['EXEC_TIME'], $taskDetails['interval'] ?? null, 0, false, $taskDetails['cronCmd'] ?? null);
         $task->setDisabled($taskDetails['disabled'] ?? false);
         $task->setDescription($identifier . (isset($taskDetails['description']) ? ': ' . $taskDetails['description'] : ''));
         $task->setTaskGroup($this->databaseTaskService->getTaskGroupUid());


### PR DESCRIPTION
Tasks were not being executed and could not be edited (or deleted) after being created by this extension.

This sets the last needed portions for this to work (`taskUid` inside the serialized object and also a proper `startDate`).